### PR TITLE
Integrate ffi pod2onchain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1204,6 +1204,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.9.4",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.10.5",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1344,6 +1364,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1364,44 +1393,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap"
-version = "4.5.48"
+name = "clang-sys"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2134bb3ea021b78629caa971416385309e0131b351b25e01dc16fb54e1b5fae"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
 dependencies = [
- "clap_builder",
- "clap_derive",
+ "glob",
+ "libc",
+ "libloading",
 ]
-
-[[package]]
-name = "clap_builder"
-version = "4.5.48"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2ba64afa3c0a6df7fa517765e31314e983f51dda798ffba27b988194fb65dc9"
-dependencies = [
- "anstream",
- "anstyle",
- "clap_lex",
- "strsim",
-]
-
-[[package]]
-name = "clap_derive"
-version = "4.5.47"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbfd7eae0b0f1a6e63d4b13c9c478de77c2eb546fba158ad50b4203dc24b9f9c"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn 2.0.106",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "colorchoice"
@@ -2970,6 +2970,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link 0.2.0",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3760,11 +3770,10 @@ dependencies = [
 [[package]]
 name = "pod2_onchain"
 version = "0.1.0"
-source = "git+https://github.com/0xPARC/pod2-onchain.git?rev=72468002f9f98460c4c513ae2c6412fddb6a41e7#72468002f9f98460c4c513ae2c6412fddb6a41e7"
+source = "git+https://github.com/0xPARC/pod2-onchain.git?rev=80209c226b51b15a060ed1de4236af476acdbe23#80209c226b51b15a060ed1de4236af476acdbe23"
 dependencies = [
  "anyhow",
- "base64 0.22.1",
- "clap",
+ "bindgen",
  "ff",
  "itertools 0.14.0",
  "lazy_static",
@@ -3814,6 +3823,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.106",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3770,7 +3770,7 @@ dependencies = [
 [[package]]
 name = "pod2_onchain"
 version = "0.1.0"
-source = "git+https://github.com/0xPARC/pod2-onchain.git?rev=80209c226b51b15a060ed1de4236af476acdbe23#80209c226b51b15a060ed1de4236af476acdbe23"
+source = "git+https://github.com/0xPARC/pod2-onchain.git?rev=490b98fe9f94b574e87d687bdb014ce6fc36cafc#490b98fe9f94b574e87d687bdb014ce6fc36cafc"
 dependencies = [
  "anyhow",
  "bindgen",

--- a/README.md
+++ b/README.md
@@ -15,24 +15,16 @@
     - queries the AD server to create a new counter, increase it, and fetches the latest state from the Synchronizer
 
 
-## API endpoints
+## Usage
+### Requirements
+Required software: [curl](https://curl.se), [git](https://git-scm.com), [rust](https://rust-lang.org), [go](https://go.dev), [tmux](https://github.com/tmux/tmux), [jq](https://github.com/jqlang/jq).
 
-### AD Server
+Copy the `.env.default` file into `.env`, and set the `PRIV_KEY` and `RPC_URL` values.
 
-```
-# Init a new counter
-curl -X POST http://0.0.0.0:8000/counter
+### Run
+To run the AD-Server & Synchronizer, together with a bash script that interacts with both, run the following command:
+- `./full-flow.sh`
 
-# Update a counter
-curl --json '5' http://0.0.0.0:8000/counter/2
-
-# Get counter state
-curl http://0.0.0.0:8000/counter/2
-```
-
-### Synchronizer
-
-```
-# Get AD state
-curl http://0.0.0.0:8000/ad_state/0x123...
-```
+To run them manually:
+- AD-Server: `RUST_LOG=ad_server=debug cargo run --release -p ad-server`
+- Synchronizer: `RUST_LOG=synchronizer=debug cargo run --release -p synchronizer`

--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ Required software: [curl](https://curl.se), [git](https://git-scm.com), [rust](h
 Copy the `.env.default` file into `.env`, and set the `PRIV_KEY` and `RPC_URL` values.
 
 ### Run
-To run the AD-Server & Synchronizer, together with a bash script that interacts with both, run the following command:
+To run the artifacts generation, and the AD-Server & Synchronizer, together with a bash script that interacts with both, run the following command:
 - `./full-flow.sh`
 
-To run them manually:
+Alternatively can run both services manually, (but take in mind that some previous steps are needed, which can be found at the `full-flow.sh` script):
 - AD-Server: `RUST_LOG=ad_server=debug cargo run --release -p ad-server`
 - Synchronizer: `RUST_LOG=synchronizer=debug cargo run --release -p synchronizer`

--- a/ad-server/src/main.rs
+++ b/ad-server/src/main.rs
@@ -143,7 +143,7 @@ async fn main() -> Result<()> {
 
     if cfg.proof_type == ProofType::Groth16 {
         // initialize groth16 memory
-        common::groth::init();
+        common::groth::init()?;
     }
 
     let (queue_tx, queue_rx) = mpsc::channel::<queue::Request>(8);

--- a/ad-server/src/main.rs
+++ b/ad-server/src/main.rs
@@ -141,6 +141,11 @@ async fn main() -> Result<()> {
         predicates,
     };
 
+    if cfg.proof_type == ProofType::Groth16 {
+        // initialize groth16 memory
+        common::groth::init();
+    }
+
     let (queue_tx, queue_rx) = mpsc::channel::<queue::Request>(8);
     let ctx = Arc::new(Context::new(
         cfg,

--- a/ad-server/src/queue.rs
+++ b/ad-server/src/queue.rs
@@ -194,7 +194,8 @@ async fn handle_update(ctx: Arc<Context>, req_id: Uuid, id: i64, op: Op) -> Resu
             PayloadProof::Plonky2(Box::new(compressed_proof))
         }
         ProofType::Groth16 => {
-            let compressed_proof = task::spawn_blocking(move || groth::prove(pod).unwrap()).await?;
+            let (compressed_proof, _) =
+                task::spawn_blocking(move || groth::prove(pod).unwrap()).await?;
             PayloadProof::Groth16(compressed_proof)
         }
     };

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -15,7 +15,7 @@ itertools = "0.14.0"
 tracing = { workspace = true }
 tracing-log = { workspace = true }
 
-pod2_onchain = { git = "https://github.com/0xPARC/pod2-onchain.git", rev = "80209c226b51b15a060ed1de4236af476acdbe23", default-features=false, features = ["disk_cache"]}
+pod2_onchain = { git = "https://github.com/0xPARC/pod2-onchain.git", rev = "490b98fe9f94b574e87d687bdb014ce6fc36cafc", default-features=false, features = ["disk_cache"]}
 
 [dev-dependencies]
 app = { path = "../app" }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -15,7 +15,7 @@ itertools = "0.14.0"
 tracing = { workspace = true }
 tracing-log = { workspace = true }
 
-pod2_onchain = { git = "https://github.com/0xPARC/pod2-onchain.git", rev = "72468002f9f98460c4c513ae2c6412fddb6a41e7", default-features=false, features = ["disk_cache"]}
+pod2_onchain = { git = "https://github.com/0xPARC/pod2-onchain.git", rev = "80209c226b51b15a060ed1de4236af476acdbe23", default-features=false, features = ["disk_cache"]}
 
 [dev-dependencies]
 app = { path = "../app" }

--- a/common/src/groth.rs
+++ b/common/src/groth.rs
@@ -112,6 +112,29 @@ mod tests {
 
     #[ignore]
     #[test]
+    fn gen_trusted_setup() -> Result<()> {
+        // if plonky2 groth16-friendly proof does not exist yet, generate it
+        if !Path::new(INPUT_PATH).is_dir() {
+            println!("generating plonky2 groth16-friendly proof");
+            pod2_onchain::pod::sample_plonky2_g16_friendly_proof(INPUT_PATH)?;
+        } else {
+            println!("plonky2 groth16-friendly proof already exists, skipping generation");
+        }
+
+        // if trusted setup does not exist yet, generate it
+        if !Path::new(OUTPUT_PATH).is_dir() {
+            println!("generating groth16's trusted setup");
+            let result = pod2_onchain::trusted_setup(INPUT_PATH, OUTPUT_PATH);
+            println!("trusted_setup result: {}", result);
+        } else {
+            println!("trusted setup already exists, skipping generation");
+        }
+
+        Ok(())
+    }
+
+    #[ignore]
+    #[test]
     fn test_prove_method() -> Result<()> {
         // obtain the pod to be proven
         let start = Instant::now();

--- a/full-flow.sh
+++ b/full-flow.sh
@@ -39,10 +39,10 @@ $tmux split-window -v
 $tmux select-layout even-vertical
 
 # run the AnchoredDatasystem server
-$tmux send-keys -t fullflow:0.0 'cd ad-server && RUST_LOG=ad_server=debug cargo run --release -p ad-server' C-m
+$tmux send-keys -t fullflow:0.0 'cd ad-server && RUST_LOG=ad_server=debug,common=debug cargo run --release -p ad-server' C-m
 
 # run the Synchronizer server
-$tmux send-keys -t fullflow:0.1 'RUST_LOG=synchronizer=debug cargo run --release -p synchronizer' C-m
+$tmux send-keys -t fullflow:0.1 'RUST_LOG=synchronizer=debug,common=debug cargo run --release -p synchronizer' C-m
 
 # leave ready the full-flow script command without executing it yet
 $tmux send-keys -t fullflow:0.2 'echo "INSTRUCTIONS: once the first two panels are already running the servers (AD & Synchronizer), execute the following command to run the integration test:"' C-m

--- a/full-flow.sh
+++ b/full-flow.sh
@@ -17,24 +17,16 @@ DB2_PATH=$(sed -n 's/^SYNCHRONIZER_SQLITE_PATH="\([^"]*\)"/\1/p' .env)
 rm -f $DB1_PATH
 rm -f $DB2_PATH
 
-echo -e "build go binary"
-git clone https://github.com/0xPARC/pod2-onchain.git tmp/pod2-onchain
-cd tmp/pod2-onchain
-git checkout restructure # rm once merged
-go build -o pod2-onchain-cli cli/main.go
-mv ./pod2-onchain-cli ../../pod2-onchain-cli
-cd -
-
 # if the sample pod proof does not exist, create it
 if [ ! -d "tmp/plonky2-proof" ]; then
-	echo -e "generate a first pod proof to have a sample for the Groth16 verifier"
+	echo -e "generate a first POD proof to have a sample for the Groth16 verifier"
 	cargo test --release -p common gen_sample_pod_proof -- --nocapture --ignored
 fi
 
 # if the trusted setup does not exist, create it
-if [ ! -d "tmp/grothartifacts" ]; then
+if [ ! -d "tmp/groth-artifacts" ]; then
 	echo -e "generate Groth16 trusted setup, using the POD's plonky2 sample"
-	./pod2-onchain-cli -t -i tmp/plonky2-proof -o tmp/grothartifacts
+	cargo test --release -p common gen_trusted_setup -- --nocapture --ignored
 fi
 
 # set new variable to use tmux in a new env

--- a/full-flow.sh
+++ b/full-flow.sh
@@ -20,13 +20,13 @@ rm -f $DB2_PATH
 echo -e "build go binary"
 git clone https://github.com/0xPARC/pod2-onchain.git tmp/pod2-onchain
 cd tmp/pod2-onchain
-git checkout fix-private-witness # TODO rm once branch merged (TMP)
-go build
-mv ./pod2-onchain ../../pod2-onchain
+git checkout restructure # rm once merged
+go build -o pod2-onchain-cli cli/main.go
+mv ./pod2-onchain-cli ../../pod2-onchain-cli
 cd -
 
 # if the sample pod proof does not exist, create it
-if [ ! -d "tmp/podproof" ]; then
+if [ ! -d "tmp/plonky2-proof" ]; then
 	echo -e "generate a first pod proof to have a sample for the Groth16 verifier"
 	cargo test --release -p common gen_sample_pod_proof -- --nocapture --ignored
 fi
@@ -34,7 +34,7 @@ fi
 # if the trusted setup does not exist, create it
 if [ ! -d "tmp/grothartifacts" ]; then
 	echo -e "generate Groth16 trusted setup, using the POD's plonky2 sample"
-	./pod2-onchain -t -i tmp/podproof -o tmp/grothartifacts
+	./pod2-onchain-cli -t -i tmp/plonky2-proof -o tmp/grothartifacts
 fi
 
 # set new variable to use tmux in a new env


### PR DESCRIPTION
- add instructions of usage to README.md, add description of packages
- integrate FFI pod2onchain new methods, replacing the usage of the cli for generating the Groth16 proofs
- replace pod2-onchain cli usage by ffi rust lib usage for generating the trusted setup