### PR TITLE
Add experimental marcos to improve statement building ergonomics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3774,6 +3774,7 @@ dependencies = [
 [[package]]
 name = "pod2_onchain"
 version = "0.1.0"
+source = "git+https://github.com/0xPARC/pod2-onchain.git?rev=36c1b426b05e3a5e13f2ba251d1ea3e8eed5bb66#36c1b426b05e3a5e13f2ba251d1ea3e8eed5bb66"
 dependencies = [
  "anyhow",
  "bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3774,7 +3774,6 @@ dependencies = [
 [[package]]
 name = "pod2_onchain"
 version = "0.1.0"
-source = "git+https://github.com/0xPARC/pod2-onchain.git?rev=0df0e99ddf37842eb8395ae06ab92a8d79b76cfb#0df0e99ddf37842eb8395ae06ab92a8d79b76cfb"
 dependencies = [
  "anyhow",
  "bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,5 +50,8 @@ pod2 = { git = "https://github.com/0xPARC/pod2?rev=main", rev = "d355e55159dbe7e
 # [patch."https://github.com/0xPARC/plonky2"]
 # plonky2 = { path = "../plonky2/plonky2" }
 
+[patch."https://github.com/0xPARC/pod2-onchain"]
+pod2_onchain = { path = "../pod2-onchain" }
+
 # [profile.release]
 # debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,8 +50,5 @@ pod2 = { git = "https://github.com/0xPARC/pod2?rev=main", rev = "d355e55159dbe7e
 # [patch."https://github.com/0xPARC/plonky2"]
 # plonky2 = { path = "../plonky2/plonky2" }
 
-[patch."https://github.com/0xPARC/pod2-onchain"]
-pod2_onchain = { path = "../pod2-onchain" }
-
 # [profile.release]
 # debug = true

--- a/ad-server/src/endpoints.rs
+++ b/ad-server/src/endpoints.rs
@@ -268,13 +268,16 @@ mod tests {
         println!("Prebuilding circuits to calculate vd_set...");
         let vd_set = &*DEFAULT_VD_SET;
         println!("vd_set calculation complete");
-        let (state_predicates, rev_predicates) = app::build_predicates(&params);
+        let batches = app::build_predicates(&params);
+        let pred_update = batches[0]
+            .predicate_ref_by_name("update")
+            .expect("update defined");
         let shrunk_main_pod_build = ShrunkMainPodSetup::new(&params).build()?;
         let pod_config = PodConfig {
             params,
             vd_set: vd_set.clone(),
-            state_predicates,
-            rev_predicates,
+            batches,
+            pred_update,
         };
 
         let (queue_tx, queue_rx) = mpsc::channel::<queue::Request>(8);

--- a/ad-server/src/queue.rs
+++ b/ad-server/src/queue.rs
@@ -160,7 +160,7 @@ async fn handle_create(ctx: Arc<Context>, req_id: Uuid) -> Result<()> {
     // send the payload to ethereum
     let payload_bytes = Payload::Create(PayloadCreate {
         id: Hash::from(RawValue::from(new_id)), // TODO hash
-        custom_predicate_ref: ctx.pod_config.state_predicates.update.clone(),
+        custom_predicate_ref: ctx.pod_config.pred_update.clone(),
         vds_root: ctx.pod_config.vd_set.root(),
     })
     .to_bytes();
@@ -204,7 +204,7 @@ async fn handle_update(ctx: Arc<Context>, req_id: Uuid, id: i64, op: Op) -> Resu
     let start = std::time::Instant::now();
 
     let mut builder = MainPodBuilder::new(&ctx.pod_config.params, &ctx.pod_config.vd_set);
-    let mut helper = Helper::new(&mut builder, &ctx.pod_config.state_predicates);
+    let mut helper = Helper::new(&mut builder, &ctx.pod_config.batches);
 
     let op = Dictionary::from(op);
     let op_raw = RawValue::from(op.commitment());
@@ -319,11 +319,7 @@ async fn handle_update_rev(ctx: Arc<Context>, req_id: Uuid, id: i64, num: i64) -
         Statement::None
     };
 
-    let mut rev_helper = RevHelper::new(
-        &mut builder,
-        &ctx.pod_config.state_predicates,
-        &ctx.pod_config.rev_predicates,
-    );
+    let mut rev_helper = RevHelper::new(&mut builder, &ctx.pod_config.batches);
     let (rev_state, rev_st_update) =
         rev_helper.st_rev_sync(rev_state, op, st_update, old_st_rev_sync);
 

--- a/app/src/macros.rs
+++ b/app/src/macros.rs
@@ -1,0 +1,116 @@
+use std::sync::Arc;
+
+use pod2::middleware::{CustomPredicateBatch, CustomPredicateRef};
+
+#[macro_export]
+macro_rules! set {
+    () => ({
+        pod2::middleware::containers::Set::new(DEPTH, std::collections::HashSet::new()).unwrap()
+    });
+    ($($val:expr),* ,) => (
+        $crate::set!($($val),*).unwrap()
+    );
+    ($($val:expr),*) => ({
+        let mut set = std::collections::HashSet::new();
+        $( set.insert($crate::middleware::Value::from($val)); )*
+        pod2::middleware::containers::Set::new(DEPTH, set).unwrap()
+    });
+}
+
+#[macro_export]
+macro_rules! dict {
+    ({ }) => (
+        pod2::middleware::containers::Dictionary::new(DEPTH, std::collections::HashMap::new()).unwrap()
+    );
+    ({ $($key:expr => $val:expr),* , }) => (
+        $crate::dict!({ $($key => $val),* }).unwrap()
+    );
+    ({ $($key:expr => $val:expr),* }) => ({
+        let mut map = std::collections::HashMap::new();
+        $( map.insert(pod2::middleware::Key::from($key.clone()), pod2::middleware::Value::from($val.clone())); )*
+        pod2::middleware::containers::Dictionary::new(DEPTH, map).unwrap()
+    });
+}
+
+#[macro_export]
+macro_rules! op {
+    (Equal($a:expr, $b:expr)) => {
+        pod2::frontend::Operation::eq($a.clone(), $b.clone())
+    };
+    (DictContains($dict:expr, $key:expr, $value:expr)) => {
+        pod2::frontend::Operation::dict_contains($dict.clone(), $key.clone(), $value.clone())
+    };
+    (DictUpdate($dict:expr, $old_dict:expr, $key:expr, $value:expr)) => {
+        pod2::frontend::Operation::dict_update(
+            $dict.clone(),
+            $old_dict.clone(),
+            $key.clone(),
+            $value.clone(),
+        )
+    };
+    (DictInsert($dict:expr, $old_dict:expr, $key:expr, $value:expr)) => {
+        pod2::frontend::Operation::dict_insert(
+            $dict.clone(),
+            $old_dict.clone(),
+            $key.clone(),
+            $value.clone(),
+        )
+    };
+    (DictDelete($dict:expr, $old_dict:expr, $key:expr)) => {
+        pod2::frontend::Operation::dict_delete($dict.clone(), $old_dict.clone(), $key.clone())
+    };
+    (SetInsert($set:expr, $old_set:expr, $value:expr)) => {
+        pod2::frontend::Operation::set_insert($set.clone(), $old_set.clone(), $value.clone())
+    };
+    (SetDelete($set:expr, $old_set:expr, $value:expr)) => {
+        pod2::frontend::Operation::set_delete($set.clone(), $old_set.clone(), $value.clone())
+    };
+}
+
+pub fn find_custom_pred_by_name(
+    batches: &[Arc<CustomPredicateBatch>],
+    name: &str,
+) -> Option<CustomPredicateRef> {
+    for batch in batches {
+        for (index, predicate) in batch.predicates().iter().enumerate() {
+            if predicate.name == name {
+                return Some(CustomPredicateRef {
+                    batch: batch.clone(),
+                    index,
+                });
+            }
+        }
+    }
+    return None;
+}
+
+#[macro_export]
+macro_rules! _st_custom_args {
+    ($builder:expr, $input_sts:expr,) => {{
+    }};
+    ($builder:expr, $input_sts:expr, $pred:ident($($args:expr),+), $($tail:tt)*) => {{
+        $input_sts.push($builder.priv_op(op!($pred($($args),+))).unwrap());
+        _st_custom_args!($builder, $input_sts, $($tail)*)
+    }};
+    ($builder:expr, $input_sts:expr, $st:expr, $($tail:tt)*) => {{
+        $input_sts.push($st);
+        _st_custom_args!($builder, $input_sts, $($tail)*)
+    }};
+}
+
+/// ```
+/// $builder: &mut MainPodBuilder
+/// $batches: &[Arc<CustomPredicateBatch]
+/// $args: Operation|Statement
+/// ```
+#[macro_export]
+macro_rules! st_custom {
+    (($builder:expr, $batches:expr), $pred:ident($($args:tt)*)) => {{
+        let custom_pred = crate::macros::find_custom_pred_by_name($batches, stringify!($pred)).unwrap();
+        let mut input_sts = Vec::new();
+        _st_custom_args!($builder, &mut input_sts, $($args)*);
+        $builder
+            .priv_op(pod2::frontend::Operation::custom(custom_pred, input_sts))
+            .unwrap()
+    }};
+}

--- a/app/src/macros.rs
+++ b/app/src/macros.rs
@@ -81,7 +81,7 @@ pub fn find_custom_pred_by_name(
             }
         }
     }
-    return None;
+    None
 }
 
 #[macro_export]
@@ -106,7 +106,7 @@ macro_rules! _st_custom_args {
 #[macro_export]
 macro_rules! st_custom {
     (($builder:expr, $batches:expr), $pred:ident($($args:tt)*)) => {{
-        let custom_pred = crate::macros::find_custom_pred_by_name($batches, stringify!($pred)).unwrap();
+        let custom_pred = $crate::macros::find_custom_pred_by_name($batches, stringify!($pred)).unwrap();
         let mut input_sts = Vec::new();
         _st_custom_args!($builder, &mut input_sts, $($args)*);
         $builder

--- a/common/src/groth.rs
+++ b/common/src/groth.rs
@@ -74,10 +74,10 @@ mod tests {
     fn compute_pod_proof() -> Result<pod2::frontend::MainPod> {
         let params = Params::default();
         let vd_set = &*DEFAULT_VD_SET;
-        let (state_predicates, _) = app::build_predicates(&params);
+        let batches = app::build_predicates(&params);
 
         let mut builder = MainPodBuilder::new(&params, vd_set);
-        let mut helper = app::Helper::new(&mut builder, &state_predicates);
+        let mut helper = app::Helper::new(&mut builder, &batches);
 
         let initial_state = Dictionary::new(
             params.max_depth_mt_containers,

--- a/common/src/payload.rs
+++ b/common/src/payload.rs
@@ -256,14 +256,11 @@ mod tests {
         println!("ShrunkMainPod setup");
         let shrunk_main_pod_build = ShrunkMainPodSetup::new(&params).build().unwrap();
         let common_data = &shrunk_main_pod_build.circuit_data.common;
-        let (state_predicates, _rev_predicates) = app::build_predicates(&params);
+        let batches = app::build_predicates(&params);
         let id = Hash([F(1), F(2), F(3), F(4)]);
         let custom_predicate_ref = CustomPredicateRef {
-            batch: CustomPredicateBatch::new_opaque(
-                "unknown".to_string(),
-                state_predicates.update.batch.id(),
-            ),
-            index: state_predicates.update.index,
+            batch: CustomPredicateBatch::new_opaque("unknown".to_string(), batches[0].id()),
+            index: batches[0].predicate_ref_by_name("update").unwrap().index,
         };
         let vd_set = &*DEFAULT_VD_SET;
         let vds_root = vd_set.root();
@@ -280,8 +277,8 @@ mod tests {
         assert_eq!(payload_create, payload_create_decoded);
 
         let mut builder = MainPodBuilder::new(&params, vd_set);
-        let (state_predicates, _rev_predicates) = app::build_predicates(&params);
-        let mut helper = app::Helper::new(&mut builder, &state_predicates);
+        let batches = app::build_predicates(&params);
+        let mut helper = app::Helper::new(&mut builder, &batches);
 
         let state =
             containers::Dictionary::new(params.max_depth_mt_containers, HashMap::new()).unwrap();


### PR DESCRIPTION
I introduced some macros to build statements and custom statements ergonomically.  The goal of adding them to this repository is to test them in the `Helper` and `RevHelper` types.

The idea is to also use this macros in future PoCs, and if they're useful move them to their own repository.

NOTE: The macro that builds statements with native predicates is not exhaustive, I just implemented the ones used in this repo, they should be extended for future usage.